### PR TITLE
Add simulated AI XML generation endpoint

### DIFF
--- a/aetherxmlbridge/src/main/java/com/group16/aetherxmlbridge/AiDiagramService.java
+++ b/aetherxmlbridge/src/main/java/com/group16/aetherxmlbridge/AiDiagramService.java
@@ -1,0 +1,33 @@
+package com.group16.aetherxmlbridge;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class AiDiagramService {
+
+    public String generateXml(ProjectData projectData) {
+
+        //simulated ai response for iteration 1
+        //currently builds XML using project data
+        //in future iteration, will be replaced by real ai api call
+        //that analyzes zoho project data and generated diagram
+
+        return """
+
+        <diagram>
+            <node>%s</node>
+            <node>AI Processor</node>
+            <node>%s</node>
+            <description>%s</description>
+            <connection from="%s" to="AI Processor"/>
+            <connection from="AI Processor" to="%s"/>
+        </diagram>
+        """.formatted(
+                projectData.getModule(),
+                projectData.getTrigger(),
+                projectData.getDescription(),
+                projectData.getModule(),
+                projectData.getTrigger()
+        );
+    }
+}

--- a/aetherxmlbridge/src/main/java/com/group16/aetherxmlbridge/DiagramController.java
+++ b/aetherxmlbridge/src/main/java/com/group16/aetherxmlbridge/DiagramController.java
@@ -7,24 +7,17 @@ import org.springframework.http.MediaType;
 @RestController
 public class DiagramController {
 
+    private final AiDiagramService aiDiagramService;
+
+    public DiagramController(AiDiagramService aiDiagramService) {
+        this.aiDiagramService = aiDiagramService;
+    }
+
     @PostMapping("/generate-xml")
     public ResponseEntity<String> generateXML(@RequestBody ProjectData projectData)
     {
 
-        String xml = """
-        <diagram>
-            <node>%s</node>
-            <node>%s</node>
-            <description>%s</description>
-            <connection from="%s" to="%s"/>
-        </diagram>
-        """.formatted(
-                projectData.getModule(),
-                projectData.getTrigger(),
-                projectData.getDescription(),
-                projectData.getTrigger(),
-                projectData.getModule()
-        );
+        String xml = aiDiagramService.generateXml(projectData);
 
         return ResponseEntity.ok()
                 .contentType(MediaType.APPLICATION_XML)


### PR DESCRIPTION
this PR implements the ai diagram generation pipeline

The /generate-xml endpoint now calls AiDiagramService which generates lucidchart compatible xml based on project data. For now, the ai response is simulated but we now have the architecture to integrate the real ai api in the future.