### PR TITLE
Add controller tests for iteration 3

### DIFF
--- a/aetherxmlbridge/src/test/java/com/group16/aetherxmlbridge/controller/AdminControllerTest.java
+++ b/aetherxmlbridge/src/test/java/com/group16/aetherxmlbridge/controller/AdminControllerTest.java
@@ -1,0 +1,108 @@
+package com.group16.aetherxmlbridge.controller;
+
+import com.group16.aetherxmlbridge.model.AppUser;
+import com.group16.aetherxmlbridge.repository.AppUserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.security.Principal;
+import java.util.List;
+import java.util.Optional;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+class AdminControllerTest {
+
+    private MockMvc mockMvc;
+    private AppUserRepository appUserRepository;
+
+    @BeforeEach
+    void setUp() {
+        appUserRepository = mock(AppUserRepository.class);
+
+        AdminController controller = new AdminController(appUserRepository);
+        mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
+    }
+
+    @Test
+    void getAllUsers_returnsAdminUsersView() throws Exception {
+        when(appUserRepository.findAll()).thenReturn(List.of());
+
+        mockMvc.perform(get("/admin/users"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("admin-users"));
+    }
+
+    @Test
+    void getAllUsers_addsUsersToModel() throws Exception {
+        AppUser user1 = new AppUser();
+        AppUser user2 = new AppUser();
+
+        when(appUserRepository.findAll()).thenReturn(List.of(user1, user2));
+
+        mockMvc.perform(get("/admin/users"))
+                .andExpect(status().isOk())
+                .andExpect(model().attributeExists("users"))
+                .andExpect(model().attribute("users", hasSize(2)));
+    }
+
+    @Test
+    void getAllUsers_withPrincipal_addsCurrentUserToModel() throws Exception {
+        AppUser currentUser = new AppUser();
+        currentUser.setEmail("admin@test.com");
+
+        when(appUserRepository.findAll()).thenReturn(List.of());
+        when(appUserRepository.findByEmail("admin@test.com")).thenReturn(Optional.of(currentUser));
+
+        mockMvc.perform(get("/admin/users").principal(new Principal() {
+            @Override
+            public String getName() {
+                return "admin@test.com";
+            }
+        }))
+                .andExpect(status().isOk())
+                .andExpect(model().attributeExists("currentUser"))
+                .andExpect(model().attribute("currentUser", currentUser));
+    }
+
+    @Test
+    void getAllUsers_withPrincipalUserNotFound_doesNotAddResolvedCurrentUserObject() throws Exception {
+        when(appUserRepository.findAll()).thenReturn(List.of());
+        when(appUserRepository.findByEmail("missing@test.com")).thenReturn(Optional.empty());
+
+        mockMvc.perform(get("/admin/users").principal(new Principal() {
+            @Override
+            public String getName() {
+                return "missing@test.com";
+            }
+        }))
+                .andExpect(status().isOk())
+                .andExpect(view().name("admin-users"))
+                .andExpect(model().attribute("activePage", "admin-users"))
+                .andExpect(model().attributeExists("users"));
+    }
+
+    @Test
+    void getAllUsers_withoutPrincipal_doesNotAddCurrentUserToModel() throws Exception {
+        when(appUserRepository.findAll()).thenReturn(List.of());
+
+        mockMvc.perform(get("/admin/users"))
+                .andExpect(status().isOk())
+                .andExpect(model().attributeDoesNotExist("currentUser"));
+    }
+
+    @Test
+    void getAllUsers_setsActivePageToAdminUsers() throws Exception {
+        when(appUserRepository.findAll()).thenReturn(List.of());
+
+        mockMvc.perform(get("/admin/users"))
+                .andExpect(status().isOk())
+                .andExpect(model().attribute("activePage", "admin-users"));
+    }
+}

--- a/aetherxmlbridge/src/test/java/com/group16/aetherxmlbridge/controller/AppErrorControllerTest.java
+++ b/aetherxmlbridge/src/test/java/com/group16/aetherxmlbridge/controller/AppErrorControllerTest.java
@@ -1,0 +1,76 @@
+package com.group16.aetherxmlbridge.controller;
+
+import jakarta.servlet.RequestDispatcher;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.test.web.ModelAndViewAssert;
+import org.springframework.ui.ExtendedModelMap;
+import org.springframework.ui.Model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class AppErrorControllerTest {
+
+    private AppErrorController controller;
+
+    @BeforeEach
+    void setUp() {
+        controller = new AppErrorController();
+    }
+
+    @Test
+    void handleError_withStatusCodeAndMessage_addsThemToModel() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setAttribute(RequestDispatcher.ERROR_STATUS_CODE, 404);
+        request.setAttribute(RequestDispatcher.ERROR_MESSAGE, "Page not found");
+
+        Model model = new ExtendedModelMap();
+
+        String viewName = controller.handleError(request, model);
+
+        assertEquals("error", viewName);
+        assertEquals("404", model.getAttribute("statusCode"));
+        assertEquals("Page not found", model.getAttribute("errorMessage"));
+    }
+
+    @Test
+    void handleError_withoutStatusCode_usesUnknown() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setAttribute(RequestDispatcher.ERROR_MESSAGE, "Something failed");
+
+        Model model = new ExtendedModelMap();
+
+        String viewName = controller.handleError(request, model);
+
+        assertEquals("error", viewName);
+        assertEquals("Unknown", model.getAttribute("statusCode"));
+        assertEquals("Something failed", model.getAttribute("errorMessage"));
+    }
+
+    @Test
+    void handleError_withoutErrorMessage_usesDefaultMessage() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setAttribute(RequestDispatcher.ERROR_STATUS_CODE, 500);
+
+        Model model = new ExtendedModelMap();
+
+        String viewName = controller.handleError(request, model);
+
+        assertEquals("error", viewName);
+        assertEquals("500", model.getAttribute("statusCode"));
+        assertEquals("An unexpected error occurred.", model.getAttribute("errorMessage"));
+    }
+
+    @Test
+    void handleError_withoutStatusCodeOrMessage_usesDefaults() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        Model model = new ExtendedModelMap();
+
+        String viewName = controller.handleError(request, model);
+
+        assertEquals("error", viewName);
+        assertEquals("Unknown", model.getAttribute("statusCode"));
+        assertEquals("An unexpected error occurred.", model.getAttribute("errorMessage"));
+    }
+}

--- a/aetherxmlbridge/src/test/java/com/group16/aetherxmlbridge/controller/ChatControllerTest.java
+++ b/aetherxmlbridge/src/test/java/com/group16/aetherxmlbridge/controller/ChatControllerTest.java
@@ -1,0 +1,71 @@
+package com.group16.aetherxmlbridge.controller;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+class ChatControllerTest {
+
+    private MockMvc mockMvc;
+    private ChatClient.CallResponseSpec callResponseSpec;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        ChatClient chatClient = mock(ChatClient.class);
+        ChatClient.Builder builder = mock(ChatClient.Builder.class);
+        ChatClient.ChatClientRequestSpec promptSpec = mock(ChatClient.ChatClientRequestSpec.class);
+        callResponseSpec = mock(ChatClient.CallResponseSpec.class);
+
+        when(builder.defaultSystem(anyString())).thenReturn(builder);
+        when(builder.build()).thenReturn(chatClient);
+        when(chatClient.prompt()).thenReturn(promptSpec);
+        when(promptSpec.user(anyString())).thenReturn(promptSpec);
+        when(promptSpec.call()).thenReturn(callResponseSpec);
+
+        ChatController controller = new ChatController(builder);
+        mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
+    }
+
+    @Test
+    void chat_validMessage_returnsAiResponse() throws Exception {
+        when(callResponseSpec.content()).thenReturn("Hello from AI");
+
+        mockMvc.perform(post("/api/ai/chat")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("\"How do I generate a diagram?\""))
+                .andExpect(status().isOk())
+                .andExpect(content().string("Hello from AI"));
+    }
+
+    @Test
+    void chat_aiThrowsException_returnsFallbackErrorMessage() throws Exception {
+        when(callResponseSpec.content()).thenThrow(new RuntimeException("API quota exceeded"));
+
+        mockMvc.perform(post("/api/ai/chat")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("\"Help me with the dashboard\""))
+                .andExpect(status().isOk())
+                .andExpect(content().string(containsString("Something went wrong: API quota exceeded")));
+    }
+
+    @Test
+    void chat_emptyMessage_stillReturnsMockedAiResponse() throws Exception {
+        when(callResponseSpec.content()).thenReturn("Please enter more details");
+
+        mockMvc.perform(post("/api/ai/chat")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("\"\""))
+                .andExpect(status().isOk())
+                .andExpect(content().string("Please enter more details"));
+    }
+}

--- a/aetherxmlbridge/src/test/java/com/group16/aetherxmlbridge/controller/PageControllerTest.java
+++ b/aetherxmlbridge/src/test/java/com/group16/aetherxmlbridge/controller/PageControllerTest.java
@@ -2,6 +2,7 @@ package com.group16.aetherxmlbridge.controller;
 
 import com.group16.aetherxmlbridge.model.AppUser;
 import com.group16.aetherxmlbridge.model.ZohoProject;
+import com.group16.aetherxmlbridge.model.ZohoScopeData;
 import com.group16.aetherxmlbridge.repository.AppUserRepository;
 import com.group16.aetherxmlbridge.service.PhoneMaskingService;
 import com.group16.aetherxmlbridge.service.ZohoApiService;
@@ -15,13 +16,12 @@ import org.springframework.web.servlet.view.InternalResourceViewResolver;
 import java.util.List;
 import java.util.Optional;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-
-import static org.mockito.ArgumentMatchers.any;
 
 class PageControllerTest {
 
@@ -40,7 +40,7 @@ class PageControllerTest {
                 appUserRepository,
                 zohoApiService,
                 phoneMaskingService
-            );
+        );
 
         InternalResourceViewResolver viewResolver = new InternalResourceViewResolver();
         viewResolver.setPrefix("/templates/");
@@ -101,49 +101,49 @@ class PageControllerTest {
     @Test
     void profile_loadsCurrentUser() throws Exception {
         AppUser user = AppUser.builder()
-            .email("test@example.com")
-            .fullName("Test User")
-            .passwordHash("hashed")
-            .role("ROLE_USER")
-            .phoneNumber("+14343143242")
-            .build();
+                .email("test@example.com")
+                .fullName("Test User")
+                .passwordHash("hashed")
+                .role("ROLE_USER")
+                .phoneNumber("+14343143242")
+                .build();
 
-    when(appUserRepository.findByEmail("test@example.com")).thenReturn(Optional.of(user));
-    when(phoneMaskingService.mask(any())).thenReturn("*** *** 1234");
-    when(phoneMaskingService.format(any())).thenReturn("+1 (434) 314-3242");
+        when(appUserRepository.findByEmail("test@example.com")).thenReturn(Optional.of(user));
+        when(phoneMaskingService.mask(any())).thenReturn("*** *** 1234");
+        when(phoneMaskingService.format(any())).thenReturn("+1 (434) 314-3242");
 
-    mockMvc.perform(get("/profile").principal(new UsernamePasswordAuthenticationToken("test@example.com", "N/A")))
-            .andExpect(status().isOk())
-            .andExpect(view().name("profile"))
-            .andExpect(model().attribute("currentUser", user))
-            .andExpect(model().attribute("maskedPhoneNumber", "*** *** 1234"))
-            .andExpect(model().attribute("formattedPhoneNumber", "+1 (434) 314-3242"));
-}
+        mockMvc.perform(get("/profile").principal(new UsernamePasswordAuthenticationToken("test@example.com", "N/A")))
+                .andExpect(status().isOk())
+                .andExpect(view().name("profile"))
+                .andExpect(model().attribute("currentUser", user))
+                .andExpect(model().attribute("maskedPhoneNumber", "*** *** 1234"))
+                .andExpect(model().attribute("formattedPhoneNumber", "+1 (434) 314-3242"));
+    }
 
     @Test
     void profile_passwordSuccessParam_setsSuccessMessage() throws Exception {
         AppUser user = AppUser.builder()
-            .email("test@example.com")
-            .fullName("Test User")
-            .passwordHash("hashed")
-            .role("ROLE_USER")
-            .phoneNumber("+14343143242")
-            .build();
+                .email("test@example.com")
+                .fullName("Test User")
+                .passwordHash("hashed")
+                .role("ROLE_USER")
+                .phoneNumber("+14343143242")
+                .build();
 
-    when(appUserRepository.findByEmail("test@example.com")).thenReturn(Optional.of(user));
-    when(phoneMaskingService.mask(any())).thenReturn("*** *** 1234");
-    when(phoneMaskingService.format(any())).thenReturn("+1 (434) 314-3242");
+        when(appUserRepository.findByEmail("test@example.com")).thenReturn(Optional.of(user));
+        when(phoneMaskingService.mask(any())).thenReturn("*** *** 1234");
+        when(phoneMaskingService.format(any())).thenReturn("+1 (434) 314-3242");
 
-    mockMvc.perform(get("/profile")
-            .param("passwordSuccess", "true")
-            .principal(new UsernamePasswordAuthenticationToken("test@example.com", "N/A")))
-            .andExpect(status().isOk())
-            .andExpect(view().name("profile"))
-            .andExpect(model().attribute("currentUser", user))
-            .andExpect(model().attribute("maskedPhoneNumber", "*** *** 1234"))
-            .andExpect(model().attribute("formattedPhoneNumber", "+1 (434) 314-3242"))
-            .andExpect(model().attribute("passwordSuccess", "Password updated successfully"));
-}
+        mockMvc.perform(get("/profile")
+                        .param("passwordSuccess", "true")
+                        .principal(new UsernamePasswordAuthenticationToken("test@example.com", "N/A")))
+                .andExpect(status().isOk())
+                .andExpect(view().name("profile"))
+                .andExpect(model().attribute("currentUser", user))
+                .andExpect(model().attribute("maskedPhoneNumber", "*** *** 1234"))
+                .andExpect(model().attribute("formattedPhoneNumber", "+1 (434) 314-3242"))
+                .andExpect(model().attribute("passwordSuccess", "Password updated successfully"));
+    }
 
     @Test
     void projects_userWithZohoToken_loadsProjectsAndFlagsConnected() throws Exception {
@@ -169,5 +169,64 @@ class PageControllerTest {
                 .andExpect(model().attribute("currentUser", user))
                 .andExpect(model().attribute("zohoConnected", true))
                 .andExpect(model().attribute("projects", List.of(project)));
+    }
+
+    @Test
+    void automationScope_userWithZohoToken_loadsScopeDataAndFlagsConnected() throws Exception {
+        AppUser user = AppUser.builder()
+                .email("test@example.com")
+                .fullName("Test User")
+                .passwordHash("hashed")
+                .role("ROLE_USER")
+                .zohoAccessToken("token123")
+                .build();
+
+        ZohoScopeData scope = new ZohoScopeData();
+        scope.setId("scope-1");
+
+        when(appUserRepository.findByEmail("test@example.com")).thenReturn(Optional.of(user));
+        when(zohoApiService.fetchScopeData(user, null)).thenReturn(List.of(scope));
+
+        mockMvc.perform(get("/automation-scope")
+                        .principal(new UsernamePasswordAuthenticationToken("test@example.com", "N/A")))
+                .andExpect(status().isOk())
+                .andExpect(view().name("automation-scope"))
+                .andExpect(model().attribute("currentUser", user))
+                .andExpect(model().attribute("zohoConnected", true))
+                .andExpect(model().attribute("scopeData", List.of(scope)))
+                .andExpect(model().attribute("activePage", "automation-scope"));
+    }
+
+    @Test
+    void automationScope_userWithoutZohoToken_setsZohoConnectedFalse() throws Exception {
+        AppUser user = AppUser.builder()
+                .email("test@example.com")
+                .fullName("Test User")
+                .passwordHash("hashed")
+                .role("ROLE_USER")
+                .zohoAccessToken(null)
+                .build();
+
+        when(appUserRepository.findByEmail("test@example.com")).thenReturn(Optional.of(user));
+
+        mockMvc.perform(get("/automation-scope")
+                        .principal(new UsernamePasswordAuthenticationToken("test@example.com", "N/A")))
+                .andExpect(status().isOk())
+                .andExpect(view().name("automation-scope"))
+                .andExpect(model().attribute("currentUser", user))
+                .andExpect(model().attribute("zohoConnected", false))
+                .andExpect(model().attributeDoesNotExist("scopeData"))
+                .andExpect(model().attribute("activePage", "automation-scope"));
+    }
+
+    @Test
+    void automationScope_withoutPrincipal_loadsPageWithActivePageOnly() throws Exception {
+        mockMvc.perform(get("/automation-scope"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("automation-scope"))
+                .andExpect(model().attribute("activePage", "automation-scope"))
+                .andExpect(model().attributeDoesNotExist("currentUser"))
+                .andExpect(model().attributeDoesNotExist("zohoConnected"))
+                .andExpect(model().attributeDoesNotExist("scopeData"));
     }
 }

--- a/aetherxmlbridge/src/test/java/com/group16/aetherxmlbridge/controller/RegenerateDiagramControllerTest.java
+++ b/aetherxmlbridge/src/test/java/com/group16/aetherxmlbridge/controller/RegenerateDiagramControllerTest.java
@@ -1,0 +1,262 @@
+package com.group16.aetherxmlbridge.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+class RegenerateDiagramControllerTest {
+
+    private MockMvc mockMvc;
+    private ChatClient.CallResponseSpec callResponseSpec;
+
+    private static final String VALID_AI_JSON = """
+            {"trigger":"User clicks Login","module":"Auth Module","description":"Validates and logs in user"}
+            """;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        ChatClient chatClient = mock(ChatClient.class);
+        ChatClient.Builder builder = mock(ChatClient.Builder.class);
+        ChatClient.ChatClientRequestSpec promptSpec = mock(ChatClient.ChatClientRequestSpec.class);
+        callResponseSpec = mock(ChatClient.CallResponseSpec.class);
+
+        when(builder.defaultSystem(anyString())).thenReturn(builder);
+        when(builder.build()).thenReturn(chatClient);
+        when(chatClient.prompt()).thenReturn(promptSpec);
+        when(promptSpec.user(anyString())).thenReturn(promptSpec);
+        when(promptSpec.call()).thenReturn(callResponseSpec);
+
+        RegenerateDiagramController controller = new RegenerateDiagramController(builder, new ObjectMapper());
+        mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
+    }
+
+    // -------------------------------------------------------------------------
+    // Happy path
+    // -------------------------------------------------------------------------
+
+    @Test
+    void regenerateDiagram_validInputs_returnsDrawioXml() throws Exception {
+        when(callResponseSpec.content()).thenReturn(VALID_AI_JSON);
+
+        mockMvc.perform(post("/regenerate-diagram")
+                .param("projectId", "P-001")
+                .param("dealName", "Acme Corp")
+                .param("stage", "Proposal")
+                .param("companyContext", "B2B SaaS company")
+                .param("productPurpose", "Project management tool")
+                .param("productionNotes", "Needs SSO")
+                .param("customerConcerns", "Data security")
+                .param("customPrompt", "Make it more detailed"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_XML))
+                .andExpect(content().string(containsString("<mxfile")))
+                .andExpect(content().string(containsString("<diagram")))
+                .andExpect(content().string(containsString("Auth Module")))
+                .andExpect(content().string(containsString("User clicks Login")))
+                .andExpect(content().string(containsString("Validates and logs in user")));
+    }
+
+    @Test
+    void regenerateDiagram_validInputs_contentDispositionHeaderContainsRegeneratedFilename() throws Exception {
+        when(callResponseSpec.content()).thenReturn(VALID_AI_JSON);
+
+        mockMvc.perform(post("/regenerate-diagram")
+                .param("dealName", "Acme Corp"))
+                .andExpect(header().string("Content-Disposition",
+                        containsString("Acme_Corp_regenerated.drawio")));
+    }
+
+    @Test
+    void regenerateDiagram_validInputs_dealNameAppearsInDiagram() throws Exception {
+        when(callResponseSpec.content()).thenReturn(VALID_AI_JSON);
+
+        mockMvc.perform(post("/regenerate-diagram")
+                .param("dealName", "Acme Corp"))
+                .andExpect(content().string(containsString("Deal: Acme Corp")));
+    }
+
+    @Test
+    void regenerateDiagram_validInputs_projectIdAppearsInDiagram() throws Exception {
+        when(callResponseSpec.content()).thenReturn(VALID_AI_JSON);
+
+        mockMvc.perform(post("/regenerate-diagram")
+                .param("projectId", "ZP-999"))
+                .andExpect(content().string(containsString("Project ID: ZP-999")));
+    }
+
+    // -------------------------------------------------------------------------
+    // Fenced JSON from AI
+    // -------------------------------------------------------------------------
+
+    @Test
+    void regenerateDiagram_aiFencedJsonResponse_stripsBackticksAndParses() throws Exception {
+        String fenced = "```json\n" + VALID_AI_JSON + "\n```";
+        when(callResponseSpec.content()).thenReturn(fenced);
+
+        mockMvc.perform(post("/regenerate-diagram"))
+                .andExpect(status().isOk())
+                .andExpect(content().string(containsString("Auth Module")));
+    }
+
+    @Test
+    void regenerateDiagram_aiFencedNoLangResponse_stripsBackticksAndParses() throws Exception {
+        String fenced = "```\n" + VALID_AI_JSON + "\n```";
+        when(callResponseSpec.content()).thenReturn(fenced);
+
+        mockMvc.perform(post("/regenerate-diagram"))
+                .andExpect(status().isOk())
+                .andExpect(content().string(containsString("Auth Module")));
+    }
+
+    // -------------------------------------------------------------------------
+    // AI error / invalid JSON
+    // -------------------------------------------------------------------------
+
+    @Test
+    void regenerateDiagram_aiReturnsInvalidJson_returnsBadRequestWithErrorXml() throws Exception {
+        when(callResponseSpec.content()).thenReturn("not valid json at all");
+
+        mockMvc.perform(post("/regenerate-diagram"))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_XML))
+                .andExpect(content().string(containsString("<error>")));
+    }
+
+    @Test
+    void regenerateDiagram_aiThrowsException_returnsBadRequestWithErrorXml() throws Exception {
+        when(callResponseSpec.content()).thenThrow(new RuntimeException("AI service unavailable"));
+
+        mockMvc.perform(post("/regenerate-diagram"))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().string(containsString("<error>")))
+                .andExpect(content().string(containsString("AI service unavailable")));
+    }
+
+    @Test
+    void regenerateDiagram_aiReturnsNullContent_returnsBadRequest() throws Exception {
+        when(callResponseSpec.content()).thenReturn(null);
+
+        mockMvc.perform(post("/regenerate-diagram"))
+                .andExpect(status().isBadRequest());
+    }
+
+    // -------------------------------------------------------------------------
+    // Default/empty params
+    // -------------------------------------------------------------------------
+
+    @Test
+    void regenerateDiagram_allParamsOmitted_usesFallbacksInDiagram() throws Exception {
+        when(callResponseSpec.content()).thenReturn(VALID_AI_JSON);
+
+        mockMvc.perform(post("/regenerate-diagram"))
+                .andExpect(status().isOk())
+                .andExpect(content().string(containsString("Deal:")))
+                .andExpect(content().string(containsString("Project ID:")))
+                .andExpect(content().string(containsString("Auth Module")))
+                .andExpect(content().string(containsString("User clicks Login")));
+    }
+
+    @Test
+    void regenerateDiagram_emptyDealName_filenameDefaultsToDiagramRegenerated() throws Exception {
+        when(callResponseSpec.content()).thenReturn(VALID_AI_JSON);
+
+        mockMvc.perform(post("/regenerate-diagram")
+                .param("dealName", ""))
+                .andExpect(header().string("Content-Disposition",
+                        containsString("diagram_regenerated.drawio")));
+    }
+
+    @Test
+    void regenerateDiagram_missingAiFields_usesFallbacksForTriggerModuleDescription() throws Exception {
+        when(callResponseSpec.content()).thenReturn("{}");
+
+        mockMvc.perform(post("/regenerate-diagram"))
+                .andExpect(status().isOk())
+                .andExpect(content().string(containsString("Trigger not found")))
+                .andExpect(content().string(containsString("Main process not found")))
+                .andExpect(content().string(containsString("Final result not found")));
+    }
+
+    // -------------------------------------------------------------------------
+    // XML / special character escaping
+    // -------------------------------------------------------------------------
+
+    @Test
+    void regenerateDiagram_specialCharsInDealName_escapedInDiagram() throws Exception {
+        when(callResponseSpec.content()).thenReturn(VALID_AI_JSON);
+
+        mockMvc.perform(post("/regenerate-diagram")
+                .param("dealName", "A&B <Corp>"))
+                .andExpect(content().string(containsString("A&amp;B &lt;Corp&gt;")));
+    }
+
+    @Test
+    void regenerateDiagram_specialCharsInDealName_sanitizedInFilename() throws Exception {
+        when(callResponseSpec.content()).thenReturn(VALID_AI_JSON);
+
+        mockMvc.perform(post("/regenerate-diagram")
+                .param("dealName", "A&B <Corp>"))
+                .andExpect(header().string("Content-Disposition",
+                        containsString("A_B__Corp__regenerated.drawio")));
+    }
+
+    @Test
+    void regenerateDiagram_doubleQuotesInContent_escapedAsHtmlEntity() throws Exception {
+        String json = """
+                {"trigger":"Say \\"Hello\\"","module":"Greeter","description":"Greets user"}
+                """;
+        when(callResponseSpec.content()).thenReturn(json);
+
+        mockMvc.perform(post("/regenerate-diagram")
+                .param("dealName", "Deal with \"quotes\""))
+                .andExpect(content().string(containsString("&quot;")));
+    }
+
+    @Test
+    void regenerateDiagram_newlinesInContent_convertedToXmlLineBreak() throws Exception {
+        when(callResponseSpec.content()).thenReturn(VALID_AI_JSON);
+
+        mockMvc.perform(post("/regenerate-diagram")
+                .param("companyContext", "Line one\nLine two"))
+                .andExpect(content().string(containsString("&#xa;")));
+    }
+
+    // -------------------------------------------------------------------------
+    // Long text truncation (shortText capped at 220 chars)
+    // -------------------------------------------------------------------------
+
+    @Test
+    void regenerateDiagram_longCompanyContext_truncatedTo220Chars() throws Exception {
+        when(callResponseSpec.content()).thenReturn(VALID_AI_JSON);
+
+        String longText = "A".repeat(300);
+
+        mockMvc.perform(post("/regenerate-diagram")
+                .param("companyContext", longText))
+                .andExpect(content().string(containsString("...")))
+                .andExpect(content().string(not(containsString("A".repeat(221)))));
+    }
+
+    @Test
+    void regenerateDiagram_contextExactly220Chars_notTruncated() throws Exception {
+        when(callResponseSpec.content()).thenReturn(VALID_AI_JSON);
+
+        String exactText = "B".repeat(220);
+
+        mockMvc.perform(post("/regenerate-diagram")
+                .param("companyContext", exactText))
+                .andExpect(content().string(not(containsString("..."))));
+    }
+}


### PR DESCRIPTION
New test files:
- RegenerateDiagramControllerTest.java
- ChatControllerTest.java
- AdminControllerTest.java
- AppErrorControllerTest.java

Updated existing test file:
- PageControllerTest.java

What was added:
- 18 tests for regenerate diagram flow
- 3 tests for chatbot controller
- 6 tests for admin controller
- 4 tests for app error controller
- 3 additional automation-scope tests in PageControllerTest

Current total automated tests: 133
Full suite passes with ./mvnw clean test